### PR TITLE
Rename `sequence_length` parameter to `length` in modular arithmetic's `sample_batch`

### DIFF
--- a/tasks/regular/modular_arithmetic.py
+++ b/tasks/regular/modular_arithmetic.py
@@ -154,8 +154,12 @@ class ModularArithmetic(task.GeneralizationTask):
     self._operators = (OP_BY_CHARACTER[op] for op in operators)
 
   @functools.partial(jax.jit, static_argnums=(0, 2, 3))
-  def sample_batch(self, rng: jnp.ndarray, batch_size: int,
-                   length: int) -> Mapping[str, jnp.ndarray]:
+  def sample_batch(
+      self,
+      rng: jnp.ndarray,
+      batch_size: int,
+      length: int,
+  ) -> Mapping[str, jnp.ndarray]:
     """Returns a batch of modular arithmetic expressions and their labels.
 
     Args:

--- a/tasks/regular/modular_arithmetic.py
+++ b/tasks/regular/modular_arithmetic.py
@@ -154,33 +154,29 @@ class ModularArithmetic(task.GeneralizationTask):
     self._operators = (OP_BY_CHARACTER[op] for op in operators)
 
   @functools.partial(jax.jit, static_argnums=(0, 2, 3))
-  def sample_batch(
-      self,
-      rng: jnp.ndarray,
-      batch_size: int,
-      sequence_length: int,
-  ) -> Mapping[str, jnp.ndarray]:
+  def sample_batch(self, rng: jnp.ndarray, batch_size: int,
+                   length: int) -> Mapping[str, jnp.ndarray]:
     """Returns a batch of modular arithmetic expressions and their labels.
 
     Args:
       rng: The jax random number generator.
       batch_size: The size of the batch returned.
-      sequence_length: The length of the sequence. As this length must be odd
+      length: The length of the sequence. As this length must be odd
         for the modular arithmetic dataset, if it's not, we force it to be by
         subtracting one to the length passed.
     """
     # Subtracting one to the length if it's not odd already.
-    if sequence_length % 2 != 1:
-      sequence_length -= 1
+    if length % 2 != 1:
+      length -= 1
 
-    batch = jnp.empty((batch_size, sequence_length), dtype=int)
+    batch = jnp.empty((batch_size, length), dtype=int)
     rng1, rng2 = jax.random.split(rng)
     remainders = jax.random.randint(rng1,
-                                    (batch_size, sequence_length // 2 + 1), 0,
+                                    (batch_size, length // 2 + 1), 0,
                                     self._modulus)
     ops = self._modulus + jnp.array(list(self._operators))
 
-    operations = jrandom.choice(rng2, ops, (batch_size, sequence_length // 2))
+    operations = jrandom.choice(rng2, ops, (batch_size, length // 2))
     batch = batch.at[:, ::2].set(remainders)
     expressions = batch.at[:, 1::2].set(operations)
 


### PR DESCRIPTION
Every task's `sample_batch` function has a `length` parameter that specifies the length of the samples generated in the batch. The exception is `ModularArithmetic`, which calls it `sequence_length`. This is inconsistent and conflicts with the provided training code:

```py
train_batch = task.sample_batch(
          next(rng_seq), length=length, batch_size=training_params.batch_size)
```

This PR addresses this issue by renaming `sequence_length` to `length`.